### PR TITLE
v0.6.0: add support for DNA+RNA allele variant syntax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,35 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.6.0]
+
+### Nucleotide allele support
+- Added support for exact DNA and RNA allele syntax, including:
+  - single-allele cis forms such as `g.[123G>A;345del]`
+  - variants *in trans* such as `r.[123c>a];[345del]`
+  - uncertain-phase forms such as `g.123G>A(;)345del`
+  - mixed-phase chains such as `c.[296T>G;476T>C];[476T>C](;)1083A>C`
+- Removed exact DNA/RNA allele syntax from the unsupported parser boundary.
+
+### Rust and Python models
+- Added allele container model on Rust backend and mirrored in Python surface:
+  - `AlleleVariant`
+  - `Allele`
+  - `AllelePhase`
+- Exposed helper views of alleles, phase, variants written in the description.
+
+### Diagnostics and tests
+- Added specific allele diagnostics for unsupported cases that still remain out
+  of scope, including `[?]` and `(;)(...)` forms.
+- Added test coverage for parsing both valid and malformed allele on both Rust
+  Python sides.
+
+### Documentation and support inventory
+- Updated the unsupported syntax inventory to mark DNA and RNA allele support
+  as available since `0.6.0`.
+- Refreshed public docs, Python docstrings, and error examples so they reflect
+  the supported nucleotide allele surface.
+
 ## [0.5.0]
 
 ### Coding-DNA coordinate support

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -79,7 +79,7 @@ dependencies = [
 
 [[package]]
 name = "py-tinyhgvs"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "pyo3",
  "tinyhgvs",
@@ -176,7 +176,7 @@ checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
 
 [[package]]
 name = "tinyhgvs"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "nom",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.5.0"
+version = "0.6.0"
 edition = "2021"
 rust-version = "1.65"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ print(variant.description.effect.edit.stop.ordinal)
 from tinyhgvs import TinyHGVSError, parse_hgvs
 
 try:
-    parse_hgvs("NC_000001.11:g.[123G>A;345del]")
+    parse_hgvs("NP_003997.1:p.Val7=/del")
 except TinyHGVSError as error:
     print(error.code)
 ```

--- a/crates/tinyhgvs/src/diagnostics.rs
+++ b/crates/tinyhgvs/src/diagnostics.rs
@@ -73,7 +73,25 @@ const UNSUPPORTED_MATCHERS: &[DiagnosticMatcher] = &[
         message: "uncertain HGVS ranges are not supported yet",
         detect: uncertain_range_fragment,
     },
-    // Examples: `g.[123G>A;345del]`, `r.[123c>a;345del]`, `p.Val7=/del`
+    // Example: `c.[2376G>C];[?]`
+    DiagnosticMatcher {
+        code: "unsupported.allele_unknown_variant",
+        message: "allele variants written as [?] are not supported yet",
+        detect: allele_unknown_variant_fragment,
+    },
+    // Example: `c.2376G>C(;)(2376G>C)`
+    DiagnosticMatcher {
+        code: "unsupported.allele_uncertain_variant_state",
+        message: "uncertain allele variant states are not supported yet",
+        detect: allele_uncertain_variant_state_fragment,
+    },
+    // Examples: `p.Val7=/del`, `p.[(Ser73Arg;Asn103del)]`
+    DiagnosticMatcher {
+        code: "unsupported.protein_allele",
+        message: "protein allele syntax is not supported yet",
+        detect: protein_allele_fragment,
+    },
+    // Example: `r.-124_-123[14];[18]`
     DiagnosticMatcher {
         code: "unsupported.allele",
         message: "allele syntax is not supported yet",
@@ -224,22 +242,35 @@ fn uncertain_range_fragment(input: &str) -> Option<String> {
     }
 }
 
-// A single top-level code is used across DNA, RNA, and protein until the model
-// grows explicit allele and phase containers.
-/// Detects allele containers across DNA, RNA, and protein syntax.
+/// Detects allele variants written as `[?]`.
+fn allele_unknown_variant_fragment(input: &str) -> Option<String> {
+    let description = variant_description_fragment(input)?;
+    description.contains("[?]").then(|| "[?]".to_string())
+}
+
+/// Detects allele forms where a variant is written but its allele state is uncertain.
+fn allele_uncertain_variant_state_fragment(input: &str) -> Option<String> {
+    let description = variant_description_fragment(input)?;
+    description.contains("(;)(").then(|| "(;)(...)".to_string())
+}
+
+/// Detects protein allele containers, which remain out of scope.
+fn protein_allele_fragment(input: &str) -> Option<String> {
+    let description = protein_description_fragment(input)?;
+    allele_like_fragment(description)
+}
+
+/// Detects other still-unsupported allele containers.
 fn allele_fragment(input: &str) -> Option<String> {
     let description = variant_description_fragment(input)?;
+    allele_like_fragment(description)
+}
 
+fn allele_like_fragment(description: &str) -> Option<String> {
     if description.contains("=/") {
         Some("=/".to_string())
-    } else if description.contains("(;)") {
-        Some("(;)".to_string())
     } else if description.contains("];[") {
         Some("];[".to_string())
-    } else if description.starts_with('[')
-        && (description.contains(';') || description.contains(','))
-    {
-        Some("[".to_string())
     } else {
         None
     }

--- a/crates/tinyhgvs/src/error.rs
+++ b/crates/tinyhgvs/src/error.rs
@@ -10,7 +10,7 @@
 //! In practice, the most useful fields are usually:
 //!
 //! - [`ParseHgvsError::code`] for a stable machine-readable diagnostic such as
-//!   `unsupported.allele`
+//!   `unsupported.allele_unknown_variant`
 //! - [`ParseHgvsError::message`] for a short explanation
 //! - [`ParseHgvsError::fragment`] for the most relevant unsupported fragment
 //! - [`ParseHgvsError::parser_version`] for tracing the crate release that
@@ -25,9 +25,10 @@ use std::fmt::{self, Display, Formatter};
 /// failure.
 ///
 /// This is especially useful for syntaxes that are valid HGVS but not yet
-/// supported by the current data model. For example, an allele expression such
-/// as `NC_000001.11:g.[123G>A;345del]` returns
-/// `code == "unsupported.allele"` rather than a generic parse failure.
+/// supported by the current data model. For example, an allele member written
+/// as `NM_004006.2:c.[2376G>C];[?]` returns
+/// `code == "unsupported.allele_unknown_variant"` rather than a generic parse
+/// failure.
 ///
 /// # Examples
 ///
@@ -132,7 +133,7 @@ impl ParseHgvsError {
         self.kind
     }
 
-    /// Returns the machine-friendly diagnostic code such as `unsupported.allele`.
+    /// Returns the machine-friendly diagnostic code such as `unsupported.allele_unknown_variant`.
     pub fn code(&self) -> &'static str {
         self.code
     }

--- a/crates/tinyhgvs/src/lib.rs
+++ b/crates/tinyhgvs/src/lib.rs
@@ -6,8 +6,8 @@
 //! - the reference sequence context such as `NM_004006.2` or `NP_003997.1`
 //! - the coordinate type such as coding DNA (`c.`), genomic DNA (`g.`), RNA
 //!   (`r.`), or protein (`p.`)
-//! - the biological description itself, represented as either a nucleotide
-//!   variant or a protein consequence
+//! - the biological description itself, represented as either an exact
+//!   nucleotide variant, a nucleotide allele, or a protein consequence
 //!
 //! The crate is intentionally small. It aims to represent common, high-value
 //! HGVS syntax clearly, while returning structured errors for syntax families
@@ -48,7 +48,25 @@
 //!                 if reference == "G" && alternate == "A"
 //!         ));
 //!     }
-//!     VariantDescription::Protein(_) => unreachable!("expected nucleotide variant"),
+//!     _ => unreachable!("expected nucleotide variant"),
+//! }
+//! ```
+//!
+//! An exact nucleotide allele keeps one first allele, an optional second
+//! established allele, and any later unphased additions:
+//!
+//! ```rust
+//! use tinyhgvs::{AllelePhase, VariantDescription, parse_hgvs};
+//!
+//! let variant = parse_hgvs("NM_004006.2:c.[2376G>C];[2376=]").unwrap();
+//!
+//! match variant.description {
+//!     VariantDescription::NucleotideAllele(allele) => {
+//!         assert_eq!(allele.allele_one.variants.len(), 1);
+//!         assert!(allele.allele_two.is_some());
+//!         assert_eq!(allele.phase, Some(AllelePhase::Trans));
+//!     }
+//!     _ => unreachable!("expected nucleotide allele"),
 //! }
 //! ```
 //!
@@ -65,7 +83,7 @@
 //!         assert!(!protein.is_predicted);
 //!         assert!(matches!(protein.effect, ProteinEffect::Edit { .. }));
 //!     }
-//!     VariantDescription::Nucleotide(_) => unreachable!("expected protein variant"),
+//!     _ => unreachable!("expected protein variant"),
 //! }
 //! ```
 //!
@@ -74,8 +92,8 @@
 //! ```rust
 //! use tinyhgvs::parse_hgvs;
 //!
-//! let error = parse_hgvs("NC_000001.11:g.[123G>A;345del]").unwrap_err();
-//! assert_eq!(error.code(), "unsupported.allele");
+//! let error = parse_hgvs("NM_004006.2:c.[2376G>C];[?]").unwrap_err();
+//! assert_eq!(error.code(), "unsupported.allele_unknown_variant");
 //! ```
 
 mod diagnostics;
@@ -85,11 +103,11 @@ mod parser;
 
 pub use error::{ParseHgvsError, ParseHgvsErrorKind};
 pub use model::{
-    Accession, CoordinateSystem, CopiedSequenceItem, HgvsVariant, Interval, LiteralSequenceItem,
-    NucleotideAnchor, NucleotideCoordinate, NucleotideEdit, NucleotideRepeatBlock,
-    NucleotideSequenceItem, NucleotideVariant, ProteinCoordinate, ProteinEdit, ProteinEffect,
-    ProteinExtensionEdit, ProteinExtensionTerminal, ProteinFrameshiftStop,
-    ProteinFrameshiftStopKind, ProteinSequence, ProteinVariant, ReferenceSpec, RepeatSequenceItem,
-    VariantDescription,
+    Accession, Allele, AllelePhase, AlleleVariant, CoordinateSystem, CopiedSequenceItem,
+    HgvsVariant, Interval, LiteralSequenceItem, NucleotideAnchor, NucleotideCoordinate,
+    NucleotideEdit, NucleotideRepeatBlock, NucleotideSequenceItem, NucleotideVariant,
+    ProteinCoordinate, ProteinEdit, ProteinEffect, ProteinExtensionEdit, ProteinExtensionTerminal,
+    ProteinFrameshiftStop, ProteinFrameshiftStopKind, ProteinSequence, ProteinVariant,
+    ReferenceSpec, RepeatSequenceItem, VariantDescription,
 };
 pub use parser::parse_hgvs;

--- a/crates/tinyhgvs/src/model.rs
+++ b/crates/tinyhgvs/src/model.rs
@@ -17,7 +17,7 @@
 ///     VariantDescription::Nucleotide(description) => {
 ///         assert_eq!(description.location.start.coordinate, -1);
 ///     }
-///     VariantDescription::Protein(_) => unreachable!("expected nucleotide variant"),
+///     _ => unreachable!("expected nucleotide variant"),
 /// }
 /// ```
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -119,7 +119,136 @@ impl CoordinateSystem {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum VariantDescription {
     Nucleotide(NucleotideVariant),
+    /// DNA or RNA allele container with one written allele, an optional second
+    /// established allele, and any later unphased additions.
+    NucleotideAllele(AlleleVariant<NucleotideVariant>),
     Protein(ProteinVariant),
+}
+
+/// Phase relationship between two established alleles.
+///
+/// # Examples
+///
+/// ```rust
+/// use tinyhgvs::{AllelePhase, VariantDescription, parse_hgvs};
+///
+/// let variant = parse_hgvs("NC_000001.11:g.123G>A(;)345del").unwrap();
+///
+/// match variant.description {
+///     VariantDescription::NucleotideAllele(allele) => {
+///         assert_eq!(allele.phase, Some(AllelePhase::Uncertain));
+///     }
+///     _ => unreachable!("expected nucleotide allele"),
+/// }
+/// ```
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AllelePhase {
+    Trans,
+    Uncertain,
+}
+
+/// One allele containing one or more exact inner variants.
+///
+/// Variants inside one allele are implicitly written in cis.
+///
+/// # Examples
+///
+/// ```rust
+/// use tinyhgvs::{VariantDescription, parse_hgvs};
+///
+/// let variant = parse_hgvs("NC_000001.11:g.[123G>A;345del]").unwrap();
+///
+/// match variant.description {
+///     VariantDescription::NucleotideAllele(allele) => {
+///         assert_eq!(allele.allele_one.variants.len(), 2);
+///     }
+///     _ => unreachable!("expected nucleotide allele"),
+/// }
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Allele<T> {
+    pub variants: Vec<T>,
+}
+
+impl<T> Allele<T> {
+    /// Returns the inner variants carried by this allele.
+    pub fn iter(&self) -> std::slice::Iter<'_, T> {
+        self.variants.iter()
+    }
+}
+
+impl<'a, T> IntoIterator for &'a Allele<T> {
+    type Item = &'a T;
+    type IntoIter = std::slice::Iter<'a, T>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.variants.iter()
+    }
+}
+
+/// Allele container holding an initial allele, an optional second established
+/// allele, and any later unphased alleles.
+///
+/// # Examples
+///
+/// ```rust
+/// use tinyhgvs::{AllelePhase, VariantDescription, parse_hgvs};
+///
+/// let variant = parse_hgvs("NM_004006.2:c.[2376G>C];[2376=]").unwrap();
+///
+/// match variant.description {
+///     VariantDescription::NucleotideAllele(allele) => {
+///         assert_eq!(allele.allele_one.variants.len(), 1);
+///         assert!(allele.allele_two.is_some());
+///         assert_eq!(allele.phase, Some(AllelePhase::Trans));
+///         assert_eq!(allele.iter().count(), 2);
+///     }
+///     _ => unreachable!("expected nucleotide allele"),
+/// }
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AlleleVariant<T> {
+    pub allele_one: Allele<T>,
+    pub allele_two: Option<Allele<T>>,
+    pub phase: Option<AllelePhase>,
+    pub alleles_unphased: Vec<Allele<T>>,
+}
+
+impl<T> AlleleVariant<T> {
+    /// Returns all written alleles in order.
+    pub fn iter(&self) -> impl Iterator<Item = &Allele<T>> {
+        std::iter::once(&self.allele_one)
+            .chain(self.allele_two.iter())
+            .chain(self.alleles_unphased.iter())
+    }
+
+    /// Returns the established trans allele pair when the relation is known.
+    pub fn phased_alleles(&self) -> Option<(&Allele<T>, &Allele<T>)> {
+        match (self.phase, self.allele_two.as_ref()) {
+            (Some(AllelePhase::Trans), Some(allele_two)) => Some((&self.allele_one, allele_two)),
+            _ => None,
+        }
+    }
+
+    /// Returns any later alleles written in uncertain relation to the
+    /// established allele state.
+    pub fn unphased_alleles(&self) -> &[Allele<T>] {
+        &self.alleles_unphased
+    }
+}
+
+impl<'a, T> IntoIterator for &'a AlleleVariant<T> {
+    type Item = &'a Allele<T>;
+    type IntoIter = std::iter::Chain<
+        std::iter::Chain<std::iter::Once<&'a Allele<T>>, std::option::Iter<'a, Allele<T>>>,
+        std::slice::Iter<'a, Allele<T>>,
+    >;
+
+    fn into_iter(self) -> Self::IntoIter {
+        std::iter::once(&self.allele_one)
+            .chain(self.allele_two.iter())
+            .chain(self.alleles_unphased.iter())
+    }
 }
 
 /// Parsed nucleotide location and edit.
@@ -141,7 +270,7 @@ pub enum VariantDescription {
 ///         assert_eq!(description.location.start.coordinate, 357);
 ///         assert_eq!(description.location.start.offset, 1);
 ///     }
-///     VariantDescription::Protein(_) => unreachable!("expected nucleotide variant"),
+///     _ => unreachable!("expected nucleotide variant"),
 /// }
 /// ```
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -165,7 +294,7 @@ pub struct NucleotideVariant {
 ///         assert!(description.is_predicted);
 ///         assert!(matches!(description.effect, ProteinEffect::Edit { .. }));
 ///     }
-///     VariantDescription::Nucleotide(_) => unreachable!("expected protein variant"),
+///     _ => unreachable!("expected protein variant"),
 /// }
 ///
 /// match extension.description {
@@ -173,7 +302,7 @@ pub struct NucleotideVariant {
 ///         ProteinEffect::Edit { edit: ProteinEdit::Extension(_), .. } => {}
 ///         _ => unreachable!("expected protein extension"),
 ///     },
-///     VariantDescription::Nucleotide(_) => unreachable!("expected protein variant"),
+///     _ => unreachable!("expected protein variant"),
 /// }
 /// ```
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -323,7 +452,7 @@ pub struct ProteinFrameshiftStop {
 ///         assert_eq!(location.start.residue, "Lys");
 ///         assert_eq!(location.end.as_ref().unwrap().residue, "Val");
 ///     }
-///     VariantDescription::Nucleotide(_) => unreachable!("expected protein variant"),
+///     _ => unreachable!("expected protein variant"),
 /// }
 /// ```
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -521,7 +650,7 @@ pub struct RepeatSequenceItem {
 ///         assert_eq!(blocks[0].unit.as_deref(), Some("CAG"));
 ///         assert_eq!(blocks[0].count, 23);
 ///     }
-///     VariantDescription::Protein(_) => unreachable!("expected nucleotide variant"),
+///     _ => unreachable!("expected nucleotide variant"),
 /// }
 /// ```
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -555,7 +684,7 @@ pub struct NucleotideRepeatBlock {
 ///         assert_eq!(item.source_location.start.coordinate, 450);
 ///         assert_eq!(item.source_location.end.as_ref().unwrap().coordinate, 470);
 ///     }
-///     VariantDescription::Protein(_) => unreachable!("expected nucleotide variant"),
+///     _ => unreachable!("expected nucleotide variant"),
 /// }
 /// ```
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -631,7 +760,7 @@ pub enum ProteinEdit {
 ///             vec!["Gln".to_string(), "Ser".to_string(), "Lys".to_string()]
 ///         );
 ///     }
-///     VariantDescription::Nucleotide(_) => unreachable!("expected protein variant"),
+///     _ => unreachable!("expected protein variant"),
 /// }
 /// ```
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/crates/tinyhgvs/src/parser.rs
+++ b/crates/tinyhgvs/src/parser.rs
@@ -16,12 +16,12 @@ use nom::{IResult, Parser};
 use crate::diagnostics::classify_parse_failure;
 use crate::error::ParseHgvsError;
 use crate::model::{
-    Accession, CoordinateSystem, CopiedSequenceItem, HgvsVariant, Interval, LiteralSequenceItem,
-    NucleotideAnchor, NucleotideCoordinate, NucleotideEdit, NucleotideRepeatBlock,
-    NucleotideSequenceItem, NucleotideVariant, ProteinCoordinate, ProteinEdit, ProteinEffect,
-    ProteinExtensionEdit, ProteinExtensionTerminal, ProteinFrameshiftStop,
-    ProteinFrameshiftStopKind, ProteinSequence, ProteinVariant, ReferenceSpec, RepeatSequenceItem,
-    VariantDescription,
+    Accession, Allele, AllelePhase, AlleleVariant, CoordinateSystem, CopiedSequenceItem,
+    HgvsVariant, Interval, LiteralSequenceItem, NucleotideAnchor, NucleotideCoordinate,
+    NucleotideEdit, NucleotideRepeatBlock, NucleotideSequenceItem, NucleotideVariant,
+    ProteinCoordinate, ProteinEdit, ProteinEffect, ProteinExtensionEdit, ProteinExtensionTerminal,
+    ProteinFrameshiftStop, ProteinFrameshiftStopKind, ProteinSequence, ProteinVariant,
+    ReferenceSpec, RepeatSequenceItem, VariantDescription,
 };
 
 type ParseResult<'a, T> = IResult<&'a str, T>;
@@ -142,6 +142,23 @@ const PROTEIN_SYMBOLS: &[&str] = &[
 ///         assert_eq!(blocks[0].unit, None);
 ///     }
 ///     _ => unreachable!("expected nucleotide variant"),
+/// }
+/// ```
+///
+/// A nucleotide allele variant with two in-trans alleles:
+///
+/// ```rust
+/// use tinyhgvs::{AllelePhase, VariantDescription, parse_hgvs};
+///
+/// let variant = parse_hgvs("NM_004006.2:c.[2376G>C];[2376=]").unwrap();
+///
+/// match variant.description {
+///     VariantDescription::NucleotideAllele(allele) => {
+///         assert_eq!(allele.allele_one.variants.len(), 1);
+///         assert!(allele.allele_two.is_some());
+///         assert_eq!(allele.phase, Some(AllelePhase::Trans));
+///     }
+///     _ => unreachable!("expected nucleotide allele"),
 /// }
 /// ```
 ///
@@ -303,6 +320,98 @@ fn nucleotide_description(
     coordinate_system: CoordinateSystem,
     input: &str,
 ) -> ParseResult<'_, VariantDescription> {
+    alt((
+        |input| nucleotide_allele_description(coordinate_system, input),
+        map(
+            |input| nucleotide_variant_description(coordinate_system, input),
+            VariantDescription::Nucleotide,
+        ),
+    ))
+    .parse(input)
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum AllelePhaseMarker {
+    Trans,
+    Uncertain,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum AlleleForm {
+    BracketedAllele,
+    PlainVariant,
+}
+
+fn verify_failure<T>(input: &str) -> ParseResult<'_, T> {
+    Err(nom::Err::Error(nom::error::Error::new(
+        input,
+        nom::error::ErrorKind::Verify,
+    )))
+}
+
+/// Parses exact DNA/RNA allele syntax such as `c.[A;B]`, `c.[A];[B]`, and
+/// `c.[A];[B](;)C`.
+///
+/// The parser works in three stages:
+/// - parse the initial allele
+/// - parse an optional established second allele
+/// - parse any later alleles written in uncertain relation to that state
+fn nucleotide_allele_description(
+    coordinate_system: CoordinateSystem,
+    input: &str,
+) -> ParseResult<'_, VariantDescription> {
+    let (input, (allele_one, first_was_bracketed)) =
+        nucleotide_initial_allele(coordinate_system, input)?;
+    let (input, established_second) = opt(|input| {
+        nucleotide_established_second_allele(
+            coordinate_system,
+            allele_one.variants.len(),
+            first_was_bracketed,
+            input,
+        )
+    })
+    .parse(input)?;
+
+    let (input, alleles_unphased) = if established_second.is_some() {
+        many0(|input| {
+            nucleotide_allele_with_phase_marker(
+                coordinate_system,
+                AllelePhaseMarker::Uncertain,
+                AlleleForm::PlainVariant,
+                input,
+            )
+        })
+        .parse(input)?
+    } else {
+        (input, Vec::new())
+    };
+
+    let (allele_two, phase) = match established_second {
+        Some((phase, allele_two)) => (Some(allele_two), Some(phase)),
+        None => (None, None),
+    };
+
+    if !first_was_bracketed && allele_two.is_none() {
+        return verify_failure(input);
+    }
+
+    Ok((
+        input,
+        VariantDescription::NucleotideAllele(AlleleVariant {
+            allele_one,
+            allele_two,
+            phase,
+            alleles_unphased,
+        }),
+    ))
+}
+
+/// Parses one exact nucleotide variant description such as `123G>A` or
+/// `357+1G>A`, without wrapping it in the top-level description enum.
+fn nucleotide_variant_description(
+    coordinate_system: CoordinateSystem,
+    input: &str,
+) -> ParseResult<'_, NucleotideVariant> {
     let (input, initial_location) = nucleotide_interval(input)?;
     let (input, edit) = nucleotide_edit(input)?;
 
@@ -315,10 +424,163 @@ fn nucleotide_description(
 
     let location = resolve_nucleotide_location(&initial_location, &edit);
 
-    Ok((
-        input,
-        VariantDescription::Nucleotide(NucleotideVariant { location, edit }),
+    Ok((input, NucleotideVariant { location, edit }))
+}
+
+/// Parses the first allele in an exact allele expression.
+///
+/// Examples:
+/// - `c.[123G>A;345del]`
+/// - `c.123G>A(;)345del`
+///
+/// Returns both the parsed allele and whether that first allele was bracketed.
+fn nucleotide_initial_allele(
+    coordinate_system: CoordinateSystem,
+    input: &str,
+) -> ParseResult<'_, (Allele<NucleotideVariant>, bool)> {
+    alt((
+        map(
+            |input| bracketed_nucleotide_allele(coordinate_system, input),
+            |allele| (allele, true),
+        ),
+        map(
+            |input| singleton_nucleotide_allele(coordinate_system, input),
+            |allele| (allele, false),
+        ),
     ))
+    .parse(input)
+}
+
+/// Parses one bracketed allele such as `[123G>A]` or `[123G>A;345del]`.
+fn bracketed_nucleotide_allele(
+    coordinate_system: CoordinateSystem,
+    input: &str,
+) -> ParseResult<'_, Allele<NucleotideVariant>> {
+    map(
+        delimited(
+            char('['),
+            separated_list1(char(';'), |input| {
+                nucleotide_variant_description(coordinate_system, input)
+            }),
+            char(']'),
+        ),
+        |variants| Allele { variants },
+    )
+    .parse(input)
+}
+
+/// Parses one plain, unbracketed variant such as `123G>A` as a singleton allele.
+fn singleton_nucleotide_allele(
+    coordinate_system: CoordinateSystem,
+    input: &str,
+) -> ParseResult<'_, Allele<NucleotideVariant>> {
+    map(
+        |input| nucleotide_variant_description(coordinate_system, input),
+        |variant| Allele {
+            variants: vec![variant],
+        },
+    )
+    .parse(input)
+}
+
+/// Parses the established second allele and its phase relation to `allele_one`.
+///
+/// This helper is for the second allele only. It does not parse later
+/// uncertain-state additions such as `c.[A];[B](;)C`.
+fn nucleotide_established_second_allele(
+    coordinate_system: CoordinateSystem,
+    allele_one_variant_count: usize,
+    first_was_bracketed: bool,
+    input: &str,
+) -> ParseResult<'_, (AllelePhase, Allele<NucleotideVariant>)> {
+    alt((
+        map(
+            |input| nucleotide_allele_two_in_trans(coordinate_system, first_was_bracketed, input),
+            |allele| (AllelePhase::Trans, allele),
+        ),
+        map(
+            |input| {
+                nucleotide_allele_two_uncertain_phase(
+                    coordinate_system,
+                    allele_one_variant_count,
+                    first_was_bracketed,
+                    input,
+                )
+            },
+            |allele| (AllelePhase::Uncertain, allele),
+        ),
+    ))
+    .parse(input)
+}
+
+/// Parses the explicit in-trans second allele in forms such as `c.[A];[B]`.
+///
+/// The early guard rejects cases like `c.A;[B]`, because a trans second allele
+/// must follow a bracketed first allele in the exact nucleotide allele syntax
+/// supported by `tinyhgvs`.
+fn nucleotide_allele_two_in_trans(
+    coordinate_system: CoordinateSystem,
+    first_was_bracketed: bool,
+    input: &str,
+) -> ParseResult<'_, Allele<NucleotideVariant>> {
+    if !first_was_bracketed {
+        return verify_failure(input);
+    }
+
+    nucleotide_allele_with_phase_marker(
+        coordinate_system,
+        AllelePhaseMarker::Trans,
+        AlleleForm::BracketedAllele,
+        input,
+    )
+}
+
+/// Parses the second allele when the relation to the first allele is uncertain,
+/// as in `c.A(;)B`.
+///
+/// The early guard rejects cases like `c.[A](;)B`. Once the first allele is
+/// bracketed and contains only one inner variant, `(;)B` should not be treated
+/// as the established second allele.
+fn nucleotide_allele_two_uncertain_phase(
+    coordinate_system: CoordinateSystem,
+    allele_one_variant_count: usize,
+    first_was_bracketed: bool,
+    input: &str,
+) -> ParseResult<'_, Allele<NucleotideVariant>> {
+    if first_was_bracketed && allele_one_variant_count == 1 {
+        return verify_failure(input);
+    }
+
+    nucleotide_allele_with_phase_marker(
+        coordinate_system,
+        AllelePhaseMarker::Uncertain,
+        AlleleForm::PlainVariant,
+        input,
+    )
+}
+
+/// Parses one allele body after a local HGVS phase marker.
+///
+/// Examples:
+/// - `;[345del]` with `Trans + BracketedAllele`
+/// - `(;)1083A>C` with `Uncertain + PlainVariant`
+fn nucleotide_allele_with_phase_marker(
+    coordinate_system: CoordinateSystem,
+    phase_marker: AllelePhaseMarker,
+    allele_form: AlleleForm,
+    input: &str,
+) -> ParseResult<'_, Allele<NucleotideVariant>> {
+    match (phase_marker, allele_form) {
+        (AllelePhaseMarker::Trans, AlleleForm::BracketedAllele) => preceded(char(';'), |input| {
+            bracketed_nucleotide_allele(coordinate_system, input)
+        })
+        .parse(input),
+        (AllelePhaseMarker::Uncertain, AlleleForm::PlainVariant) => preceded(tag("(;)"), |input| {
+            singleton_nucleotide_allele(coordinate_system, input)
+        })
+        .parse(input),
+        _ => verify_failure(input),
+    }
 }
 
 /// Parses nucleotide location as a single position/coordinate or an interval

--- a/crates/tinyhgvs/tests/test_diagnostics.rs
+++ b/crates/tinyhgvs/tests/test_diagnostics.rs
@@ -8,13 +8,6 @@ fn parse_error(example: &str) -> tinyhgvs::ParseHgvsError {
 fn classifies_supported_diagnostic_codes() {
     let cases = [
         (
-            "NC_000001.11:g.[123G>A;345del]",
-            "unsupported.allele",
-            ParseHgvsErrorKind::UnsupportedSyntax,
-            "allele syntax is not supported yet",
-            Some("["),
-        ),
-        (
             "NC_000023.11:g.(31060227_31100351)_(33274278_33417151)dup",
             "unsupported.uncertain_range",
             ParseHgvsErrorKind::UnsupportedSyntax,
@@ -64,11 +57,32 @@ fn classifies_supported_diagnostic_codes() {
             Some("::"),
         ),
         (
+            "NM_004006.2:c.[2376G>C];[?]",
+            "unsupported.allele_unknown_variant",
+            ParseHgvsErrorKind::UnsupportedSyntax,
+            "allele variants written as [?] are not supported yet",
+            Some("[?]"),
+        ),
+        (
+            "NM_004006.2:c.2376G>C(;)(2376G>C)",
+            "unsupported.allele_uncertain_variant_state",
+            ParseHgvsErrorKind::UnsupportedSyntax,
+            "uncertain allele variant states are not supported yet",
+            Some("(;)(...)"),
+        ),
+        (
             "r.-124_-123[14];[18]",
             "unsupported.allele",
             ParseHgvsErrorKind::UnsupportedSyntax,
             "allele syntax is not supported yet",
             Some("];["),
+        ),
+        (
+            "NP_003997.1:p.Val7=/del",
+            "unsupported.protein_allele",
+            ParseHgvsErrorKind::UnsupportedSyntax,
+            "protein allele syntax is not supported yet",
+            Some("=/"),
         ),
         (
             "r.-128_-126[(600_800)]",
@@ -123,9 +137,16 @@ fn classifies_supported_diagnostic_codes() {
 fn prioritizes_specific_rna_codes_before_generic_ones() {
     let splicing = parse_error("NC_000023.11(NM_004006.2):r.spl");
     let uncertain = parse_error("NM_004006.2:r.(222_226)insg");
+    let unknown_member = parse_error("NM_004006.2:c.[2376G>C];[?]");
+    let uncertain_state = parse_error("NM_004006.2:c.2376G>C(;)(2376G>C)");
 
     assert_eq!(splicing.code(), "unsupported.rna_splicing_outcome");
     assert_eq!(uncertain.code(), "unsupported.rna_uncertain_position");
+    assert_eq!(unknown_member.code(), "unsupported.allele_unknown_variant");
+    assert_eq!(
+        uncertain_state.code(),
+        "unsupported.allele_uncertain_variant_state"
+    );
 }
 
 #[test]

--- a/crates/tinyhgvs/tests/test_parser.rs
+++ b/crates/tinyhgvs/tests/test_parser.rs
@@ -1,6 +1,6 @@
 use tinyhgvs::{
-    parse_hgvs, CoordinateSystem, CopiedSequenceItem, LiteralSequenceItem, NucleotideEdit,
-    NucleotideSequenceItem, ProteinEdit, ProteinEffect, ProteinExtensionTerminal,
+    parse_hgvs, AllelePhase, CoordinateSystem, CopiedSequenceItem, LiteralSequenceItem,
+    NucleotideEdit, NucleotideSequenceItem, ProteinEdit, ProteinEffect, ProteinExtensionTerminal,
     ProteinFrameshiftStopKind, RepeatSequenceItem, VariantDescription,
 };
 
@@ -346,6 +346,196 @@ fn parses_nucleotide_repeat_variants() {
             );
         }
         other => panic!("expected nucleotide variant, found {other:?}"),
+    }
+}
+
+#[test]
+fn parses_nucleotide_allele_variants() {
+    let cis = parse_variant("NC_000001.11:g.[123G>A;345del]");
+    let trans = parse_variant("NM_004006.3:r.[123c>a];[345del]");
+    let uncertain = parse_variant("NC_000001.11:g.123G>A(;)345del");
+    let unchanged = parse_variant("NM_004006.2:c.[2376G>C];[2376=]");
+    let mixed = parse_variant("NM_004006.2:c.[296T>G;476T>C];[476T>C](;)1083A>C");
+
+    let VariantDescription::NucleotideAllele(cis) = cis.description else {
+        panic!("expected nucleotide allele");
+    };
+    assert_eq!(cis.allele_one.variants.len(), 2);
+    assert!(cis.allele_two.is_none());
+    assert!(cis.phase.is_none());
+    assert!(cis.alleles_unphased.is_empty());
+    assert_eq!(cis.iter().count(), 1);
+    assert!(matches!(
+        cis.allele_one.variants[0].edit,
+        NucleotideEdit::Substitution { ref reference, ref alternate }
+            if reference == "G" && alternate == "A"
+    ));
+    assert_eq!(cis.allele_one.variants[1].location.start.coordinate, 345);
+    assert_eq!(cis.allele_one.variants[1].edit, NucleotideEdit::Deletion);
+
+    let VariantDescription::NucleotideAllele(trans) = trans.description else {
+        panic!("expected nucleotide allele");
+    };
+    assert_eq!(trans.allele_one.variants.len(), 1);
+    assert_eq!(trans.phase, Some(AllelePhase::Trans));
+    let trans_allele_two = trans.allele_two.as_ref().expect("expected allele two");
+    assert_eq!(trans_allele_two.variants.len(), 1);
+    assert!(trans.alleles_unphased.is_empty());
+    assert_eq!(trans_allele_two.variants[0].location.start.coordinate, 345);
+
+    let VariantDescription::NucleotideAllele(uncertain) = uncertain.description else {
+        panic!("expected nucleotide allele");
+    };
+    assert_eq!(uncertain.allele_one.variants.len(), 1);
+    assert_eq!(uncertain.phase, Some(AllelePhase::Uncertain));
+    let uncertain_allele_two = uncertain.allele_two.as_ref().expect("expected allele two");
+    assert!(uncertain.alleles_unphased.is_empty());
+    assert_eq!(
+        uncertain_allele_two.variants[0].location.start.coordinate,
+        345
+    );
+    assert_eq!(
+        uncertain_allele_two.variants[0].edit,
+        NucleotideEdit::Deletion
+    );
+
+    let VariantDescription::NucleotideAllele(unchanged) = unchanged.description else {
+        panic!("expected nucleotide allele");
+    };
+    assert_eq!(unchanged.allele_one.variants.len(), 1);
+    assert_eq!(unchanged.phase, Some(AllelePhase::Trans));
+    let unchanged_allele_two = unchanged.allele_two.as_ref().expect("expected allele two");
+    assert!(unchanged.alleles_unphased.is_empty());
+    assert_eq!(
+        unchanged_allele_two.variants[0].location.start.coordinate,
+        2376
+    );
+    assert_eq!(
+        unchanged_allele_two.variants[0].edit,
+        NucleotideEdit::NoChange
+    );
+
+    let VariantDescription::NucleotideAllele(mixed) = mixed.description else {
+        panic!("expected nucleotide allele");
+    };
+    assert_eq!(mixed.allele_one.variants.len(), 2);
+    assert_eq!(mixed.phase, Some(AllelePhase::Trans));
+    let mixed_allele_two = mixed.allele_two.as_ref().expect("expected allele two");
+    assert_eq!(mixed.alleles_unphased.len(), 1);
+    assert_eq!(mixed_allele_two.variants[0].location.start.coordinate, 476);
+    assert_eq!(
+        mixed.alleles_unphased[0].variants[0]
+            .location
+            .start
+            .coordinate,
+        1083
+    );
+}
+
+#[test]
+fn reports_nucleotide_allele_helper_views() {
+    let cis = parse_variant("NC_000001.11:g.[123G>A;345del]");
+    let trans = parse_variant("NM_004006.3:r.[123c>a];[345del]");
+    let uncertain = parse_variant("NC_000001.11:g.123G>A(;)345del");
+    let mixed = parse_variant("NM_004006.2:c.[296T>G];[476T>C](;)1083G>C(;)1406del");
+
+    let VariantDescription::NucleotideAllele(cis) = cis.description else {
+        panic!("expected nucleotide allele");
+    };
+    assert!(cis.phased_alleles().is_none());
+    assert_eq!(cis.unphased_alleles().len(), 0);
+    assert_eq!(cis.allele_one.variants.len(), 2);
+    assert!(cis.allele_two.is_none());
+
+    let VariantDescription::NucleotideAllele(trans) = trans.description else {
+        panic!("expected nucleotide allele");
+    };
+    let (allele_one, allele_two) = trans.phased_alleles().expect("expected phased alleles");
+    assert_eq!(allele_one.variants.len(), 1);
+    assert_eq!(allele_two.variants.len(), 1);
+    assert_eq!(trans.unphased_alleles().len(), 0);
+    assert_eq!(trans.allele_one.variants.len(), 1);
+    assert_eq!(
+        trans
+            .allele_two
+            .as_ref()
+            .expect("expected second haplotype")
+            .variants
+            .len(),
+        1
+    );
+
+    let VariantDescription::NucleotideAllele(uncertain) = uncertain.description else {
+        panic!("expected nucleotide allele");
+    };
+    assert!(uncertain.phased_alleles().is_none());
+    assert_eq!(uncertain.unphased_alleles().len(), 0);
+    assert_eq!(uncertain.allele_one.variants.len(), 1);
+    assert_eq!(
+        uncertain
+            .allele_two
+            .as_ref()
+            .expect("expected second haplotype")
+            .variants[0]
+            .location
+            .start
+            .coordinate,
+        345
+    );
+
+    let VariantDescription::NucleotideAllele(mixed) = mixed.description else {
+        panic!("expected nucleotide allele");
+    };
+    assert!(mixed.phased_alleles().is_some());
+    assert_eq!(mixed.unphased_alleles().len(), 2);
+    assert_eq!(mixed.allele_one.variants.len(), 1);
+    assert_eq!(
+        mixed
+            .allele_two
+            .as_ref()
+            .expect("expected second haplotype")
+            .variants[0]
+            .location
+            .start
+            .coordinate,
+        476
+    );
+    assert_eq!(
+        mixed.unphased_alleles()[0].variants[0]
+            .location
+            .start
+            .coordinate,
+        1083
+    );
+    assert_eq!(
+        mixed.unphased_alleles()[1].variants[0]
+            .location
+            .start
+            .coordinate,
+        1406
+    );
+}
+
+#[test]
+fn rejects_malformed_nucleotide_allele_syntax() {
+    let cases = [
+        "NC_000001.11:g.[123G>A](;)345del",
+        "NC_000001.11:g.123G>A(;)[345del]",
+        "NC_000001.11:g.[123G>A](;)[345del]",
+        "NC_000001.11:g.[123G>A;;345del]",
+        "NC_000001.11:g.[123G>A](;)",
+        "NC_000001.11:g.[123G>A][345del]",
+        "NC_000001.11:g.[123G>A;]",
+        "NM_004006.3:r.;[123c>a]",
+    ];
+
+    for input in cases {
+        let error = parse_hgvs(input).unwrap_err();
+        assert_eq!(
+            error.code(),
+            "invalid.syntax",
+            "unexpected code for {input}"
+        );
     }
 }
 

--- a/docs/api/errors.md
+++ b/docs/api/errors.md
@@ -7,8 +7,12 @@ Representative examples:
 
 - Invalid syntax:
   `NM_004006.2:c.5697delA` -> `invalid.syntax`
-- Unsupported allele syntax:
-  `NC_000001.11:g.[123G>A;345del]` -> `unsupported.allele`
+- Unsupported allele member syntax:
+  `NM_004006.2:c.[2376G>C];[?]` -> `unsupported.allele_unknown_variant`
+- Unsupported uncertain allele-member state:
+  `NM_004006.2:c.[2376G>C](;)(1083A>C)` -> `unsupported.allele_uncertain_variant_state`
+- Unsupported protein allele syntax:
+  `NP_003997.1:p.Val7=/del` -> `unsupported.protein_allele`
 - Unsupported quantified protein insertion syntax:
   `p.Arg78_Gly79insXaa[23]` -> `unsupported.protein_insertion_payload`
 - Unsupported RNA special-state syntax:

--- a/docs/index.md
+++ b/docs/index.md
@@ -68,7 +68,7 @@ Inspect an unsupported syntax error:
 from tinyhgvs import TinyHGVSError, parse_hgvs
 
 try:
-    parse_hgvs("NC_000001.11:g.[123G>A;345del]")
+    parse_hgvs("NP_003997.1:p.Val7=/del")
 except TinyHGVSError as error:
     print(error.code)
     print(error.fragment)

--- a/docs/unsupported.md
+++ b/docs/unsupported.md
@@ -22,7 +22,9 @@ the collapsible sections below each table.
 
 | Diagnostic code category | Biology category | Representative example | Supported since |
 | --- | --- | --- | --- |
-| `allele` | DNA allele | `NC_000001.11:g.[123G>A;345del]` | `-` |
+| `allele` | DNA allele | `NC_000001.11:g.[123G>A;345del]` | `0.6.0` |
+| `allele_unknown_variant` | DNA allele with variant unknown | `NC_000001.11:g.[123G>A];[?]` | `-` |
+| `allele_uncertain_variant_state` | DNA allele with uncertain variant state | `NC_000001.11:g.[123G>A](;)(345del)` | `-` |
 | `uncertain_range` | DNA range-uncertain edit | `NC_000023.10:g.(33038277_33038278)C>T` | `-` |
 | `dna_repeat` | DNA repeated sequence | `NC_000014.8:g.123CAG[23]` | `0.2.0` |
 | `telomeric_position` | DNA telomeric coordinate | `NC_000023.11:g.pter_qtersup` | `-` |
@@ -35,7 +37,15 @@ the collapsible sections below each table.
     === "allele"
 
         - `NC_000001.11:g.[123G>A];[345del]`
-        - `NC_000023.11:g.33344590_33344592=/dup`
+        - `NC_000001.11:g.123G>A(;)345del`
+
+    === "allele_unknown_variant"
+
+        - `NC_000001.11:g.[123G>A;345del];[?]`
+
+    === "allele_uncertain_variant_state"
+
+        - `NC_000001.11:g.[123G>A](;)(345del)`
 
     === "uncertain_range"
 
@@ -50,7 +60,9 @@ the collapsible sections below each table.
 
 | Diagnostic code category | Biology category | Representative example | Supported since |
 | --- | --- | --- | --- |
-| `allele` | RNA allele | `LRG_199t1:r.[76a>u;103del]` | `-` |
+| `allele` | RNA allele | `LRG_199t1:r.[76a>u;103del]` | `0.6.0` |
+| `allele_unknown_variant` | RNA allele with variant unknown | `NM_004006.3:r.[123c>a];[?]` | `-` |
+| `allele_uncertain_variant_state` | RNA allele with uncertain variant state | `NM_004006.3:r.[123c>a](;)(345del)` | `-` |
 | `rna_special_state` | RNA special-state outcome | `NM_004006.3:r.?` | `-` |
 | `rna_uncertain_position` | RNA uncertain insertion | `NM_004006.2:r.(222_226)insg` | `-` |
 | `rna_repeat` | RNA repeated sequence | `NM_004006.3:r.-124_-123[14]` | `0.2.0` |
@@ -63,7 +75,15 @@ the collapsible sections below each table.
     === "allele"
 
         - `NM_004006.3:r.[123c>a;345del]`
-        - `NM_004006.3:r.[123c>a];[345del]`
+        - `NM_004006.3:r.123c>a(;)345del`
+
+    === "allele_unknown_variant"
+
+        - `NM_004006.3:r.[123c>a;345del];[?]`
+
+    === "allele_uncertain_variant_state"
+
+        - `NM_004006.3:r.[123c>a](;)(345del)`
 
     === "rna_special_state"
 

--- a/py-tinyhgvs/python/tinyhgvs/__init__.py
+++ b/py-tinyhgvs/python/tinyhgvs/__init__.py
@@ -13,6 +13,9 @@ from .api import parse_hgvs
 from .errors import ParseHgvsErrorKind, TinyHGVSError
 from .models import (
     Accession,
+    Allele,
+    AllelePhase,
+    AlleleVariant,
     CopiedSequenceItem,
     CoordinateSystem,
     HgvsVariant,
@@ -59,6 +62,9 @@ except PackageNotFoundError:
 
 __all__ = [
     "Accession",
+    "Allele",
+    "AllelePhase",
+    "AlleleVariant",
     "CopiedSequenceItem",
     "CoordinateSystem",
     "HgvsVariant",

--- a/py-tinyhgvs/python/tinyhgvs/api.py
+++ b/py-tinyhgvs/python/tinyhgvs/api.py
@@ -54,6 +54,16 @@ def parse_hgvs(input: str) -> HgvsVariant:
         >>> repeat.description.edit.blocks[0].unit is None
         True
 
+        Two alleles *in trans*:
+
+        >>> allele = parse_hgvs("NM_004006.2:c.[2376G>C];[2376=]")
+        >>> allele.description.phase
+        <AllelePhase.TRANS: 'trans'>
+        >>> len(tuple(allele.description.allele_one))
+        1
+        >>> len(tuple(allele.description.allele_two))
+        1
+
         A predicted protein consequence:
 
         >>> protein = parse_hgvs("NP_003997.1:p.(Trp24Ter)")

--- a/py-tinyhgvs/python/tinyhgvs/errors.py
+++ b/py-tinyhgvs/python/tinyhgvs/errors.py
@@ -24,7 +24,7 @@ class ParseHgvsErrorKind(str, Enum):
 
         Unsupported syntax that is recognized but not implemented:
         >>> try:
-        ...     parse_hgvs("NC_000001.11:g.[123G>A;345del]")
+        ...     parse_hgvs("NM_004006.2:c.[2376G>C];[?]")
         ... except TinyHGVSError as error:
         ...     error.kind
         <ParseHgvsErrorKind.UNSUPPORTED_SYNTAX: 'unsupported_syntax'>
@@ -43,20 +43,21 @@ class TinyHGVSError(ValueError):
 
     Attributes:
         kind: Broad error class derived from the Rust error model.
-        code: Stable diagnostic code such as ``unsupported.allele``.
+        code: Stable diagnostic code in the format of ``unsupported.*``.
         message: Human-readable explanation of the failure.
         input: Original HGVS string that failed to parse.
         fragment: Relevant unsupported fragment when one was detected.
         parser_version: ``tinyhgvs`` version that produced the error.
 
     Examples:
-        Unsupported allele syntax:
+        Unsupported allele variant with variant unknown:
+
         >>> from tinyhgvs import TinyHGVSError, parse_hgvs
         >>> try:
-        ...     parse_hgvs("NC_000001.11:g.[123G>A;345del]")
+        ...     parse_hgvs("NM_004006.2:c.[2376G>C];[?]")
         ... except TinyHGVSError as error:
         ...     (error.kind.value, error.code, error.fragment)
-        ('unsupported_syntax', 'unsupported.allele', '[')
+        ('unsupported_syntax', 'unsupported.allele_unknown_variant', '[?]')
 
         Invalid syntax:
         >>> try:

--- a/py-tinyhgvs/python/tinyhgvs/models/__init__.py
+++ b/py-tinyhgvs/python/tinyhgvs/models/__init__.py
@@ -16,10 +16,14 @@ from dataclasses import dataclass
 from typing import TypeAlias
 
 from .nucleotide import (
+    Allele,
+    AllelePhase,
+    AlleleVariant,
     CopiedSequenceItem,
-    NucleotideDeletionInsertionEdit,
+    LiteralSequenceItem,
     NucleotideAnchor,
     NucleotideCoordinate,
+    NucleotideDeletionInsertionEdit,
     NucleotideEdit,
     NucleotideInsertionEdit,
     NucleotideRepeatBlock,
@@ -28,12 +32,11 @@ from .nucleotide import (
     NucleotideSequenceOmittedEdit,
     NucleotideSubstitutionEdit,
     NucleotideVariant,
-    LiteralSequenceItem,
     RepeatSequenceItem,
 )
 from .protein import (
-    ProteinDeletionInsertionEdit,
     ProteinCoordinate,
+    ProteinDeletionInsertionEdit,
     ProteinEdit,
     ProteinEditEffect,
     ProteinEffect,
@@ -58,10 +61,13 @@ from .shared import (
     ReferenceSpec,
 )
 
-VariantDescription: TypeAlias = NucleotideVariant | ProteinVariant
+VariantDescription: TypeAlias = (
+    NucleotideVariant | AlleleVariant[NucleotideVariant] | ProteinVariant
+)
 """Tagged union for supported top-level variant models:
 
 - [`NucleotideVariant`][tinyhgvs.models.nucleotide.NucleotideVariant]
+- [`AlleleVariant`][tinyhgvs.models.nucleotide.AlleleVariant]
 - [`ProteinVariant`][tinyhgvs.models.protein.ProteinVariant]
 """
 
@@ -122,6 +128,9 @@ class HgvsVariant:
 
 __all__ = [
     "Accession",
+    "Allele",
+    "AllelePhase",
+    "AlleleVariant",
     "CopiedSequenceItem",
     "CoordinateSystem",
     "HgvsVariant",

--- a/py-tinyhgvs/python/tinyhgvs/models/nucleotide.py
+++ b/py-tinyhgvs/python/tinyhgvs/models/nucleotide.py
@@ -10,13 +10,271 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import Literal, TypeAlias
+from typing import Generic, Iterator, Literal, TypeAlias
 
 from .shared import (
     CoordinateSystem,
     Interval,
     ReferenceSpec,
+    VariantT,
 )
+
+
+class AllelePhase(str, Enum):
+    """Model describing phase between/among alleles.
+
+    Attributes:
+        TRANS: Alleles are *In-trans* phase.
+        UNCERTAIN: Phase between/among alleles is uncertain.
+
+    Examples:
+        *In-trans* alleles:
+        >>> from tinyhgvs import parse_hgvs
+        >>> variants = parse_hgvs("NM_004006.2:c.[2376G>C];[3103del]")
+        >>> variants.description.phase
+        <AllelePhase.TRANS: 'trans'>
+
+        Uncertain phase:
+        >>> variant = parse_hgvs("NC_000001.11:g.123G>A(;)345del")
+        >>> variant.description.phase
+        <AllelePhase.UNCERTAIN: 'uncertain'>
+    """
+
+    TRANS = "trans"
+    UNCERTAIN = "uncertain"
+
+
+@dataclass(frozen=True, slots=True)
+class Allele(Generic[VariantT]):
+    """One allele carrying one or more variants *in cis*.
+
+    Attributes:
+        variants: Variants described on the same allele and therefore treated
+            as occurring together *in cis*.
+
+    Examples:
+        >>> from tinyhgvs import parse_hgvs
+        >>> variant = parse_hgvs("NC_000001.11:g.[123G>A;345del]")
+        >>> len(variant.description.allele_one.variants)
+        2
+    """
+
+    variants: tuple[VariantT, ...]
+
+    def __iter__(self) -> Iterator[VariantT]:
+        """Return an iterator over variants carried by an allele in order.
+
+        Returns:
+            (Iterator[VariantT]): Iterator over variants carried by this allele,
+                in the order they appear in the written description.
+        Examples:
+
+            >>> from tinyhgvs import parse_hgvs
+            >>> allele = parse_hgvs(
+            ...     "NC_000001.11:g.[123G>A;345del]"
+            ... ).description.allele_one
+            >>> len(tuple(allele))
+            2
+        """
+        return iter(self.variants)
+
+
+@dataclass(frozen=True, slots=True)
+class AlleleVariant(Generic[VariantT]):
+    """Structured representation of HGVS allele variant syntax.
+
+    An allele variant may describe:
+
+    - a single allele carrying one or more variants.
+    - two alleles with an explicit phase relationship.
+    - additional alleles whose relation to the established allele state is
+      uncertain.
+
+    Attributes:
+        allele_one: First allele in the allele-variant description.
+        allele_two: Second allele, if present.
+        phase: Phase relation between ``allele_one`` and ``allele_two``. This
+            is ``None`` when only one allele is described.
+        alleles_unphased: Additional alleles in uncertain relation to the
+            allele state established by ``allele_one`` and ``allele_two``.
+
+    Examples:
+        Variants *in cis* on a single allele:
+
+        >>> from tinyhgvs import parse_hgvs
+        >>> desc = parse_hgvs("NC_000023.10:g.[30683643A>G;33038273T>G]").description
+        >>> len(tuple(variant.description))
+        1
+        >>> desc.allele_two is None
+        True
+        >>> desc.phase is None
+        True
+        >>> len(desc.allele_one.variants)
+        2
+
+        Two alleles *in trans*:
+
+        >>> desc = parse_hgvs("NM_004006.2:c.[2376G>C];[3103del]").description
+        >>> desc.allele_two is not None
+        True
+        >>> desc.phase
+        <AllelePhase.TRANS: 'trans'>
+        >>> len(desc.allele_one.variants)
+        1
+        >>> len(desc.allele_two.variants)
+        1
+
+        Additional alleles with uncertain phase:
+
+        >>> desc = parse_hgvs(
+        ...     "NM_004006.2:c.[296T>G;476T>C];[476T>C](;)1083A>C"
+        ... ).description
+        >>> desc.phase
+        <AllelePhase.TRANS: 'trans'>
+        >>> len(desc.unphased_alleles)
+        1
+        >>> len(desc.unphased_alleles[0].variants)
+        1
+    """
+
+    allele_one: Allele[VariantT]
+    allele_two: Allele[VariantT] | None = None
+    phase: AllelePhase | None = None
+    alleles_unphased: tuple[Allele[VariantT], ...] = ()
+
+    def __iter__(self) -> Iterator[Allele[VariantT]]:
+        """Iterate over alleles in description order.
+
+        Yields:
+            (Allele[VariantT]): Alleles in description order: ``allele_one``, then
+                ``allele_two`` when present, followed by any entries in
+                ``alleles_unphased``.
+
+        Notes:
+            Iteration preserves the structural order of the HGVS allele-variant
+            description. It does not infer or reorder alleles by phase.
+
+        Examples:
+            >>> from tinyhgvs import parse_hgvs
+            >>> desc = parse_hgvs("NM_004006.2:c.[2376G>C];[3103del]").description
+            >>> len(tuple(desc))
+            2
+
+            >>> desc = parse_hgvs(
+            ...     "NM_004006.2:c.[296T>G;476T>C];[476T>C](;)1083A>C"
+            ... ).description
+            >>> len(tuple(desc))
+            3
+        """
+
+        yield self.allele_one
+        if self.allele_two is not None:
+            yield self.allele_two
+        yield from self.alleles_unphased
+
+    @property
+    def phased_alleles(
+        self,
+    ) -> tuple[Allele[VariantT], Allele[VariantT]] | None:
+        """Return the established phased allele pair, if present.
+
+        Returns:
+            (tuple[Allele[VariantT], Allele[VariantT]] | None): The established
+                phased allele pair as ``(allele_one, allele_two)``
+                when this description contains two established alleles with an
+                explicit phase relationship; otherwise, ``None``.
+
+        Notes:
+            This property reports only the primary phased allele pair represented
+            by ``allele_one`` and ``allele_two``. Alleles in
+            ``alleles_unphased`` are not included.
+
+        Examples:
+            A single allele does not establish a phased pair:
+
+            >>> from tinyhgvs import parse_hgvs
+            >>> desc = parse_hgvs("NC_000001.11:g.[123G>A;345del]").description
+            >>> desc.phased_alleles is None
+            True
+
+            Two alleles with established phase return a pair:
+
+            >>> desc = parse_hgvs("NM_004006.2:c.[2376G>C];[2376=]").description
+            >>> desc.phase
+            <AllelePhase.TRANS: 'trans'>
+            >>> pair = desc.phased_alleles
+            >>> pair is not None
+            True
+            >>> len(pair[0].variants), len(pair[1].variants)
+            (1, 1)
+
+            Two alleles with uncertain phase does not return a pair:
+
+            >>> desc = parse_hgvs("NC_000001.11:g.123G>A(;)345del").description
+            >>> desc.phase
+            <AllelePhase.UNCERTAIN: 'uncertain'>
+            >>> pair = desc.phased_alleles
+            >>> pair is None
+            True
+
+            Additional alleles with uncertain (unestablished) phase:
+
+            >>> desc = parse_hgvs(
+            ...     "NM_004006.2:c.[296T>G;476T>C];[476T>C](;)1083A>C"
+            ... ).description
+            >>> pair = desc.phased_alleles
+            >>> pair is not None
+            True
+            >>> len(desc.alleles_unphased)
+            1
+        """
+        if self.phase is AllelePhase.TRANS and self.allele_two is not None:
+            return (self.allele_one, self.allele_two)
+        return None
+
+    @property
+    def unphased_alleles(self) -> tuple[Allele[VariantT], ...]:
+        """Return alleles with uncertain relation to the allele state established
+            by ``allele_one`` and ``allele_two``.
+
+        Returns:
+            (tuple[Allele[VariantT], ...]): Alleles written after the established
+                allele state whose relation to that state is uncertain. Empty
+                when not present.
+
+        Notes:
+            This property exposes the additional alleles stored in
+            ``alleles_unphased``. It does not include ``allele_one`` or
+            ``allele_two``.
+
+        Examples:
+            Uncertain phase between two primary alleles does not create an
+            unphased tail:
+
+            >>> from tinyhgvs import parse_hgvs
+            >>> desc = parse_hgvs("NC_000001.11:g.123G>A(;)345del").description
+            >>> len(desc.unphased_alleles)
+            0
+
+            One additional unphased allele to the established state:
+
+            >>> desc = parse_hgvs(
+            ...     "NM_004006.2:c.[296T>G];[476T>C](;)1083A>C"
+            ... ).description
+            >>> len(desc.unphased_alleles)
+            1
+            >>> len(desc.unphased_alleles[0].variants)
+            1
+
+            Multiple additions of unphased alleles to the established state:
+
+            >>> desc = parse_hgvs(
+            ...     "NM_004006.2:c.[296T>G];[476T>C](;)1083A>C(;)1406del"
+            ... ).description
+            >>> len(desc.unphased_alleles)
+            2
+        """
+        return self.alleles_unphased
 
 
 class NucleotideAnchor(str, Enum):
@@ -548,7 +806,9 @@ class NucleotideVariant:
 
 
 __all__ = [
-    "CoordinateSystem",
+    "Allele",
+    "AllelePhase",
+    "AlleleVariant",
     "CopiedSequenceItem",
     "NucleotideDeletionInsertionEdit",
     "NucleotideAnchor",

--- a/py-tinyhgvs/python/tinyhgvs/models/shared.py
+++ b/py-tinyhgvs/python/tinyhgvs/models/shared.py
@@ -122,6 +122,7 @@ class ReferenceSpec:
 
 
 PositionT = TypeVar("PositionT")
+VariantT = TypeVar("VariantT")
 
 
 @dataclass(frozen=True, slots=True)

--- a/py-tinyhgvs/src/lib.rs
+++ b/py-tinyhgvs/src/lib.rs
@@ -1,13 +1,13 @@
 use pyo3::prelude::*;
 use pyo3::types::{PyModule, PyTuple};
 use tinyhgvs::{
-    parse_hgvs as parse_hgvs_core, Accession, CoordinateSystem, CopiedSequenceItem,
-    HgvsVariant as CoreHgvsVariant, Interval, LiteralSequenceItem, NucleotideAnchor,
-    NucleotideCoordinate, NucleotideEdit, NucleotideRepeatBlock, NucleotideSequenceItem,
-    ParseHgvsError as CoreParseHgvsError, ParseHgvsErrorKind, ProteinCoordinate, ProteinEdit,
-    ProteinEffect, ProteinExtensionEdit, ProteinExtensionTerminal, ProteinFrameshiftStop,
-    ProteinFrameshiftStopKind, ProteinSequence, ReferenceSpec, RepeatSequenceItem,
-    VariantDescription,
+    parse_hgvs as parse_hgvs_core, Accession, Allele, AllelePhase, AlleleVariant, CoordinateSystem,
+    CopiedSequenceItem, HgvsVariant as CoreHgvsVariant, Interval, LiteralSequenceItem,
+    NucleotideAnchor, NucleotideCoordinate, NucleotideEdit, NucleotideRepeatBlock,
+    NucleotideSequenceItem, NucleotideVariant, ParseHgvsError as CoreParseHgvsError,
+    ParseHgvsErrorKind, ProteinCoordinate, ProteinEdit, ProteinEffect, ProteinExtensionEdit,
+    ProteinExtensionTerminal, ProteinFrameshiftStop, ProteinFrameshiftStopKind, ProteinSequence,
+    ReferenceSpec, RepeatSequenceItem, VariantDescription,
 };
 
 const PY_ERRORS_MODULE: &str = "tinyhgvs.errors";
@@ -176,6 +176,70 @@ impl<'py> PyModelCodec<'py> {
         PyTuple::new(self.py, items)
     }
 
+    fn allele_phase(&self, value: AllelePhase) -> PyResult<Bound<'py, PyAny>> {
+        let name = match value {
+            AllelePhase::Trans => "trans",
+            AllelePhase::Uncertain => "uncertain",
+        };
+        self.class("AllelePhase")?.call1((name,))
+    }
+
+    fn nucleotide_variant(&self, value: &NucleotideVariant) -> PyResult<Bound<'py, PyAny>> {
+        self.class("NucleotideVariant")?.call1((
+            self.nucleotide_interval(&value.location)?,
+            self.nucleotide_edit(&value.edit)?,
+        ))
+    }
+
+    fn nucleotide_variants_tuple(
+        &self,
+        value: &[NucleotideVariant],
+    ) -> PyResult<Bound<'py, PyTuple>> {
+        let items = value
+            .iter()
+            .map(|item| self.nucleotide_variant(item))
+            .collect::<PyResult<Vec<_>>>()?;
+        PyTuple::new(self.py, items)
+    }
+
+    fn nucleotide_allele(&self, value: &Allele<NucleotideVariant>) -> PyResult<Bound<'py, PyAny>> {
+        self.class("Allele")?
+            .call1((self.nucleotide_variants_tuple(&value.variants)?,))
+    }
+
+    fn nucleotide_alleles_tuple(
+        &self,
+        value: &[Allele<NucleotideVariant>],
+    ) -> PyResult<Bound<'py, PyTuple>> {
+        let items = value
+            .iter()
+            .map(|item| self.nucleotide_allele(item))
+            .collect::<PyResult<Vec<_>>>()?;
+        PyTuple::new(self.py, items)
+    }
+
+    fn nucleotide_allele_variant(
+        &self,
+        value: &AlleleVariant<NucleotideVariant>,
+    ) -> PyResult<Bound<'py, PyAny>> {
+        let allele_two = value
+            .allele_two
+            .as_ref()
+            .map(|allele| self.nucleotide_allele(allele))
+            .transpose()?;
+        let phase = value
+            .phase
+            .map(|phase| self.allele_phase(phase))
+            .transpose()?;
+
+        self.class("AlleleVariant")?.call1((
+            self.nucleotide_allele(&value.allele_one)?,
+            allele_two,
+            phase,
+            self.nucleotide_alleles_tuple(&value.alleles_unphased)?,
+        ))
+    }
+
     fn protein_sequence(&self, value: &ProteinSequence) -> PyResult<Bound<'py, PyAny>> {
         let residues = PyTuple::new(self.py, &value.residues)?;
         self.class("ProteinSequence")?.call1((residues,))
@@ -306,10 +370,8 @@ impl<'py> PyModelCodec<'py> {
 
     fn description(&self, value: &VariantDescription) -> PyResult<Bound<'py, PyAny>> {
         match value {
-            VariantDescription::Nucleotide(value) => self.class("NucleotideVariant")?.call1((
-                self.nucleotide_interval(&value.location)?,
-                self.nucleotide_edit(&value.edit)?,
-            )),
+            VariantDescription::Nucleotide(value) => self.nucleotide_variant(value),
+            VariantDescription::NucleotideAllele(value) => self.nucleotide_allele_variant(value),
             VariantDescription::Protein(value) => self
                 .class("ProteinVariant")?
                 .call1((value.is_predicted, self.protein_effect(&value.effect)?)),

--- a/py-tinyhgvs/tests/test_parser.py
+++ b/py-tinyhgvs/tests/test_parser.py
@@ -5,6 +5,8 @@ import sys
 import pytest
 import tinyhgvs as tinyhgvs_package
 from tinyhgvs import (
+    AllelePhase,
+    AlleleVariant,
     CoordinateSystem,
     CopiedSequenceItem,
     LiteralSequenceItem,
@@ -254,6 +256,122 @@ def test_parses_nucleotide_repeat_variants():
     assert composite_edit.blocks[2].location.start.coordinate == 490
     assert composite_edit.blocks[2].location.end is not None
     assert composite_edit.blocks[2].location.end.coordinate == 499
+
+
+def test_parses_nucleotide_allele_variants():
+    cis = parse_hgvs("NC_000001.11:g.[123G>A;345del]")
+    trans = parse_hgvs("NM_004006.3:r.[123c>a];[345del]")
+    uncertain = parse_hgvs("NC_000001.11:g.123G>A(;)345del")
+    unchanged = parse_hgvs("NM_004006.2:c.[2376G>C];[2376=]")
+    mixed = parse_hgvs("NM_004006.2:c.[296T>G;476T>C];[476T>C](;)1083A>C")
+
+    assert isinstance(cis.description, AlleleVariant)
+    assert len(cis.description.allele_one.variants) == 2
+    assert cis.description.allele_two is None
+    assert cis.description.phase is None
+    assert cis.description.alleles_unphased == ()
+    assert len(tuple(cis.description)) == 1
+    assert cis.description.allele_one.variants[0].edit.reference == "G"
+    assert cis.description.allele_one.variants[0].edit.alternate == "A"
+    assert cis.description.allele_one.variants[1].location.start.coordinate == 345
+    assert (
+        cis.description.allele_one.variants[1].edit
+        is NucleotideSequenceOmittedEdit.DELETION
+    )
+
+    assert isinstance(trans.description, AlleleVariant)
+    assert len(trans.description.allele_one.variants) == 1
+    assert trans.description.phase is AllelePhase.TRANS
+    assert trans.description.allele_two is not None
+    assert len(trans.description.allele_two.variants) == 1
+    assert trans.description.alleles_unphased == ()
+    assert trans.description.allele_two.variants[0].location.start.coordinate == 345
+
+    assert isinstance(uncertain.description, AlleleVariant)
+    assert len(uncertain.description.allele_one.variants) == 1
+    assert uncertain.description.phase is AllelePhase.UNCERTAIN
+    assert uncertain.description.allele_two is not None
+    assert uncertain.description.allele_two.variants[0].location.start.coordinate == 345
+    assert uncertain.description.alleles_unphased == ()
+    assert uncertain.description.allele_two.variants[0].edit is NucleotideSequenceOmittedEdit.DELETION
+
+    assert isinstance(unchanged.description, AlleleVariant)
+    assert len(unchanged.description.allele_one.variants) == 1
+    assert unchanged.description.phase is AllelePhase.TRANS
+    assert unchanged.description.allele_two is not None
+    assert unchanged.description.allele_two.variants[0].location.start.coordinate == 2376
+    assert unchanged.description.allele_two.variants[0].edit is NucleotideSequenceOmittedEdit.NO_CHANGE
+
+    assert isinstance(mixed.description, AlleleVariant)
+    assert len(mixed.description.allele_one.variants) == 2
+    assert mixed.description.phase is AllelePhase.TRANS
+    assert mixed.description.allele_two is not None
+    assert len(mixed.description.alleles_unphased) == 1
+    assert mixed.description.allele_two.variants[0].location.start.coordinate == 476
+    assert (
+        mixed.description.alleles_unphased[0].variants[0].location.start.coordinate
+        == 1083
+    )
+
+
+def test_reports_nucleotide_allele_helper_views():
+    cis = parse_hgvs("NC_000001.11:g.[123G>A;345del]")
+    trans = parse_hgvs("NM_004006.3:r.[123c>a];[345del]")
+    uncertain = parse_hgvs("NC_000001.11:g.123G>A(;)345del")
+    mixed = parse_hgvs("NM_004006.2:c.[296T>G];[476T>C](;)1083G>C(;)1406del")
+
+    assert cis.description.phased_alleles is None
+    assert cis.description.unphased_alleles == ()
+    assert len(cis.description.allele_one.variants) == 2
+    assert cis.description.allele_two is None
+    assert len(tuple(cis.description.allele_one)) == 2
+
+    trans_pair = trans.description.phased_alleles
+    assert trans_pair is not None
+    assert len(trans_pair[0].variants) == 1
+    assert len(trans_pair[1].variants) == 1
+    assert trans.description.unphased_alleles == ()
+    assert len(trans.description.allele_one.variants) == 1
+    assert trans.description.allele_two is not None
+    assert trans.description.allele_two.variants[0].location.start.coordinate == 345
+    assert len(tuple(trans.description)) == 2
+
+    assert uncertain.description.phased_alleles is None
+    assert uncertain.description.unphased_alleles == ()
+    assert len(uncertain.description.allele_one.variants) == 1
+    assert uncertain.description.allele_two is not None
+    assert (
+        uncertain.description.allele_two.variants[0].location.start.coordinate
+        == 345
+    )
+
+    mixed_pair = mixed.description.phased_alleles
+    assert mixed_pair is not None
+    assert len(mixed.description.unphased_alleles) == 2
+    assert len(mixed.description.allele_one.variants) == 1
+    assert mixed.description.allele_two is not None
+    assert mixed.description.allele_two.variants[0].location.start.coordinate == 476
+    assert mixed.description.unphased_alleles[0].variants[0].location.start.coordinate == 1083
+    assert mixed.description.unphased_alleles[1].variants[0].location.start.coordinate == 1406
+
+
+def test_rejects_malformed_nucleotide_allele_variants():
+    cases = [
+        "NC_000001.11:g.[123G>A](;)345del",
+        "NC_000001.11:g.123G>A(;)[345del]",
+        "NC_000001.11:g.[123G>A](;)[345del]",
+        "NC_000001.11:g.[123G>A;;345del]",
+        "NC_000001.11:g.[123G>A](;)",
+        "NC_000001.11:g.[123G>A][345del]",
+        "NC_000001.11:g.[123G>A;]",
+        "NM_004006.3:r.;[123c>a]",
+    ]
+
+    for input_value in cases:
+        with pytest.raises(TinyHGVSError) as exc_info:
+            parse_hgvs(input_value)
+
+        assert exc_info.value.code == "invalid.syntax"
 
 
 def test_parses_protein_substitution_and_no_change_variants():
@@ -624,16 +742,22 @@ def test_rejects_examples_deferred_to_future_work():
     ("example", "code", "kind", "fragment"),
     [
         (
-            "NC_000001.11:g.[123G>A;345del]",
-            "unsupported.allele",
-            ParseHgvsErrorKind.UNSUPPORTED_SYNTAX,
-            "[",
-        ),
-        (
             "NC_000023.11:g.(31060227_31100351)_(33274278_33417151)dup",
             "unsupported.uncertain_range",
             ParseHgvsErrorKind.UNSUPPORTED_SYNTAX,
             "(",
+        ),
+        (
+            "NM_004006.2:c.[2376G>C];[?]",
+            "unsupported.allele_unknown_variant",
+            ParseHgvsErrorKind.UNSUPPORTED_SYNTAX,
+            "[?]",
+        ),
+        (
+            "NM_004006.2:c.[2376G>C](;)(1083A>C)",
+            "unsupported.allele_uncertain_variant_state",
+            ParseHgvsErrorKind.UNSUPPORTED_SYNTAX,
+            "(;)(...)",
         ),
         (
             "r.-124_-123[14];[18]",
@@ -682,6 +806,12 @@ def test_rejects_examples_deferred_to_future_work():
             "unsupported.rna_adjoined_transcript",
             ParseHgvsErrorKind.UNSUPPORTED_SYNTAX,
             "::",
+        ),
+        (
+            "NP_003997.1:p.Val7=/del",
+            "unsupported.protein_allele",
+            ParseHgvsErrorKind.UNSUPPORTED_SYNTAX,
+            "=/",
         ),
         (
             "p.(Gln18)[(70_80)]",


### PR DESCRIPTION
This PR adds nucleotide allele variant support in `v0.6.0` (also see #11).

Highlights:

- Added support for:
  - *In-cis* allele forms such as `g.[123G>A;345del]`
  - *In-trans* allele forms such as `r.[123c>a];[345del]`
  - Uncertain-phase forms such as `g.123G>A(;)345del`
  - Mixed-phase chains such as `c.[296T>G;476T>C];[476T>C](;)1083A>C`
- Added a shallow shared allele container model on Rust and Python:
  - `AlleleVariant`
  - `Allele`
  - `AllelePhase`
- Narrowed unsupported allele diagnostics for cases like `[?]` and `(;)(...)` as yet-to-be-supported.
- Updateed the unsupported inventory to mark exact DNA/RNA allele syntax as  supported since `0.6.0`